### PR TITLE
Allow 'notes' field to be null (yaml)/None (py)

### DIFF
--- a/sync_known_issues.py
+++ b/sync_known_issues.py
@@ -212,8 +212,10 @@ def issues_equal(a, b):
     if 'id' in y: del y['id']
 
     # Remove any trailing newlines in notes
-    x['notes'] = x['notes'].strip()
-    y['notes'] = y['notes'].strip()
+    if x['notes'] is not None:
+        x['notes'] = x['notes'].strip()
+    if y['notes'] is not None:
+        y['notes'] = y['notes'].strip()
 
     # Ensure consistent sort order
     x['environments'].sort()

--- a/test_sync_known_issues.py
+++ b/test_sync_known_issues.py
@@ -39,3 +39,16 @@ def test_issue_equal_not_equal():
     is_equal = sync_known_issues.issues_equal(a, b)
     assert not is_equal
 
+def test_issue_url_note_null():
+    config_file = "test_data/test-issues.yaml"
+    config_data = sync_known_issues.parse_files([config_file])
+
+    a = config_data['LKFT-ltp-staging']['known_issues'][0]
+
+    b = a.copy()
+    b['url'] = None
+    b['notes'] = None
+
+    is_equal = sync_known_issues.issues_equal(a, b)
+    assert not is_equal
+


### PR DESCRIPTION
When notes field is set to null, the following is observed:

    Traceback (most recent call last):
      File "./sync_known_issues.py", line 339, in <module>
        main()
      File "./sync_known_issues.py", line 324, in main
        if issues_equal(api_known_issue, known_issue_api_object):
      File "./sync_known_issues.py", line 215, in issues_equal
        x['notes'] = x['notes'].strip()
    AttributeError: 'NoneType' object has no attribute 'strip'

Add a test and a null check to the offending code.

Signed-off-by: Dan Rue <dan.rue@linaro.org>