### PR TITLE
LKFT: kselftest: rseq: Function not implemented on older kernel

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -1199,6 +1199,61 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=3923
     active: true
     intermittent: false
+  - environments: *environments_all
+    notes: >
+      LKFT: Kselftest: rseq: : Function not implemented on older kernel
+    projects:
+    - lkft/linux-stable-rc-4.14-oe
+    - lkft/linux-stable-rc-4.9-oe
+    - lkft/linux-stable-rc-4.4-oe
+    test_name: kselftest/rseq_basic_percpu_ops_test
+    url: https://bugs.linaro.org/show_bug.cgi?id=3923
+    active: true
+    intermittent: false
+  - environments: *environments_all
+    notes: >
+      LKFT: Kselftest: rseq: : Function not implemented on older kernel
+    projects:
+    - lkft/linux-stable-rc-4.14-oe
+    - lkft/linux-stable-rc-4.9-oe
+    - lkft/linux-stable-rc-4.4-oe
+    test_name: kselftest/rseq_basic_test
+    url: https://bugs.linaro.org/show_bug.cgi?id=3923
+    active: true
+    intermittent: false
+  - environments: *environments_all
+    notes: >
+      LKFT: Kselftest: rseq: : Function not implemented on older kernel
+    projects:
+    - lkft/linux-stable-rc-4.14-oe
+    - lkft/linux-stable-rc-4.9-oe
+    - lkft/linux-stable-rc-4.4-oe
+    test_name: kselftest/rseq_param_test
+    url: https://bugs.linaro.org/show_bug.cgi?id=3923
+    active: true
+    intermittent: false
+  - environments: *environments_all
+    notes: >
+      LKFT: Kselftest: rseq: : Function not implemented on older kernel
+    projects:
+    - lkft/linux-stable-rc-4.14-oe
+    - lkft/linux-stable-rc-4.9-oe
+    - lkft/linux-stable-rc-4.4-oe
+    test_name: kselftest/rseq_param_test_benchmark
+    url: https://bugs.linaro.org/show_bug.cgi?id=3923
+    active: true
+    intermittent: false
+  - environments: *environments_all
+    notes: >
+      LKFT: Kselftest: rseq: : Function not implemented on older kernel
+    projects:
+    - lkft/linux-stable-rc-4.14-oe
+    - lkft/linux-stable-rc-4.9-oe
+    - lkft/linux-stable-rc-4.4-oe
+    test_name: kselftest/rseq_param_test_compare_twice
+    url: https://bugs.linaro.org/show_bug.cgi?id=3923
+    active: true
+    intermittent: false
   - environments:
     - qemu_i386
     notes: >


### PR DESCRIPTION
Adding rseq tests as known issues for older kernels for all devices.
 - 4.14
 - 4.9
 - 4.4

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>