### PR TITLE
Make requests calls more strict

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2018, Linaro Limited
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
+all: test dry-run
+
 test:
 	pytest
+
+dry-run:
+	./sync_known_issues.py -c kselftests-production.yaml --dry-run
+	./sync_known_issues.py -c ltp-production.yaml --dry-run
+	./sync_known_issues.py -c libhugetlbfs-production.yaml --dry-run

--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ the following fields:
 ## Example
 
 See test_data/test-issues.yaml or one of the yaml files in this directory.
+
+## Developing
+
+See Makefile rules 'test' and 'dry-run'. Best practice is to simply run 'make'
+before committing a change, which will run all unit tests and also run with
+--dry-run against the local yaml files. --dry-run does not require
+authentication to qa-reports.

--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -450,10 +450,6 @@ projects:
     intermittent: false
     matrix_apply:
     - environments:
-      - dragonboard-410c
-      projects:
-      - lkft/linux-stable-rc-4.4-oe
-    - environments:
       - hi6220-hikey
       projects:
       - lkft/linaro-hikey-stable-rc-4.4-oe

--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -413,7 +413,7 @@ projects:
       LKFT: linux-mainline, 4.9 and 4.4: x15: rtctest - PIE delta error: 0.018197
       should be close to 0.015625
     projects:
-    - lkft/linux-stable-rc-4.4-oe
+    - lkft/linaro-hikey-stable-rc-4.4-oe
     test_name: kselftest/rtctest
     url: https://bugs.linaro.org/show_bug.cgi?id=3402
     active: true
@@ -443,16 +443,20 @@ projects:
     url: null
     active: true
     intermittent: false
-  - environments:
-    - dragonboard-410c
-    - hi6220-hikey
+  - test_name: kselftest/test_bpf.sh
     notes: null
-    projects:
-    - lkft/linux-stable-rc-4.4-oe
-    test_name: kselftest/test_bpf.sh
     url: null
     active: true
     intermittent: false
+    matrix_apply:
+    - environments:
+      - dragonboard-410c
+      projects:
+      - lkft/linux-stable-rc-4.4-oe
+    - environments:
+      - hi6220-hikey
+      projects:
+      - lkft/linaro-hikey-stable-rc-4.4-oe
   - environments: *environments_qemu
     notes: null
     projects: *projects_all
@@ -506,7 +510,7 @@ projects:
     notes: >
       LKFT: linux-mainline: x15: printf.sh bitmap.sh zram.sh netns_netlink - section
       4 reloc 2 sym memset: relocation 28 out of range (0xbf046044 -> 0xc109f720)
-    url: null
+    url: https://bugs.linaro.org/show_bug.cgi?id=3484
     active: true
     intermittent: false
     matrix_apply:


### PR DESCRIPTION
Use raise_for_status() to fail for any http request that contains
errors. This eliminates a bunch of error handling code.

Add an assert to ensure some environments are found. There are some
known issue definitions that had invalid environments listed, which
resulted in them not being applied as anticipated. This has also been
fixed.

Signed-off-by: Dan Rue <dan.rue@linaro.org>