### PR TITLE
LTP: open-posix: condvar_pthread_cond_wait_1 intermittent

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -528,3 +528,12 @@ projects:
     url: http://lists.linux.it/pipermail/ltp/2018-October/009752.html
     active: true
     intermittent: false
+  - environments: *environments_all
+    notes: >
+      LKFT: LTP: open posix: condvar_pthread_cond_wait_1 intermittent failures
+      on all devices
+    projects: *projects_all
+    test_name: ltp-open-posix-tests/condvar_pthread_cond_wait_1
+    url: https://bugs.linaro.org/show_bug.cgi?id=3973
+    active: true
+    intermittent: true


### PR DESCRIPTION
Set ltp-open-posix-tests/condvar_pthread_cond_wait_1 as intermittent.

Signed-off-by: Rafael David Tinoco <rafael.tinoco@linaro.org>