### PR TITLE
LTP: cve-2015-3290 should be skipped in all environments

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -378,12 +378,12 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=3852
     active: true
     intermittent: false
-  - environments: *environments_intel
+  - environments: *environments_all
     notes: >
-      LKFT: LTP: cve-2015-3290 failed intermittently on qemu_x86_64
+      LKFT: LTP: cve-2015-3290 should be skipped in all
     projects: *projects_all
     test_name: ltp-cve-tests/cve-2015-3290
-    url: https://bugs.linaro.org/show_bug.cgi?id=3910
+    url: https://bugs.linaro.org/show_bug.cgi?id=3991
     active: true
     intermittent: true
   - environments: *environments_all


### PR DESCRIPTION
The CVE is x86_64 related only:

"""
If an NMI returns via espfix64 and is interrupted during espfix64 setup
by another NMI, the return state is corrupt.  This is exploitable for
reliable privilege escalation on any Linux x86_64 system in which
untrusted code can arrange for espfix64 to be invoked and for NMIs to be
nested.
"""

And it seems to be passing in almost every test run (there was 1 failure
here and there for x86_64). During a lkft-triage review meeting we
agreed that we shouldn't focus in this particular test since it is
testing a particular way of corrupting the x86_64 (only) NMI handler
when there are nested NMIs coming from userland.

Signed-off-by: Rafael David Tinoco <rafael.tinoco@linaro.org>