### PR TITLE
kselftests: adding kvm_clear_dirty_log_test to known issues list

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -691,6 +691,7 @@ projects:
     - kselftest/kvm_cr4_cpuid_sync_test
     - kselftest/kvm_state_test
     - kselftest/kvm_dirty_log_test
+    - kselftest/kvm_clear_dirty_log_test
     - kselftest/kvm_platform_info_test
     - kselftest/kvm_evmcs_test
     url: https://bugs.linaro.org/show_bug.cgi?id=3741


### PR DESCRIPTION
KVM tests do not build for arm32/64 and i386 so adding them to known issues.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>