### PR TITLE
kselftests: Adding bpf_test_netcnt as known issue for older kernel ve…

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -889,7 +889,7 @@ projects:
     - kselftest-vsyscall-mode-none/net_tls
     - kselftest-vsyscall-mode-native/net_tls
     url: https://bugs.linaro.org/show_bug.cgi?id=3925
-    active: true
+    active: false
     intermittent: false
   - test_names:
     - kselftest/rseq_basic_percpu_ops_test

--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -801,22 +801,25 @@ projects:
       - lkft/linux-stable-rc-4.9-oe
       - lkft/linux-stable-rc-4.4-oe
       - lkft/linaro-hikey-stable-rc-4.4-oe
-  - environments:
-    - qemu_arm
-    - qemu_i386
-    - qemu_x86_64
-    - x15
-    - x86
-    - i386
+  - test_names:
+    - kselftest/bpf_test_socket_cookie
+    - kselftest-vsyscall-mode-none/bpf_test_socket_cookie
+    - kselftest-vsyscall-mode-native/bpf_test_socket_cookie
+    matrix_apply:
+    - environments: *environments_32bit
+      projects: *projects_all
+    - environments: *environments_all
+      projects:
+      - lkft/linux-stable-rc-4.20-oe
+      - lkft/linux-stable-rc-4.19-oe
+      - lkft/linux-stable-rc-4.14-oe
+      - lkft/linux-stable-rc-4.9-oe
+      - lkft/linux-stable-rc-4.4-oe
+      - lkft/linaro-hikey-stable-rc-4.4-oe
     notes: >
       bpf: test_socket_cookie failed on x86_64 and arm32
       libbpf: ./socket_cookie_prog.o doesn't provide kernel version
       (test_socket_cookie.c:154: errno: No such file or directory) Failed to load ./socket_cookie_prog.o
-    projects: *projects_all
-    test_names:
-    - kselftest/bpf_test_socket_cookie
-    - kselftest-vsyscall-mode-none/bpf_test_socket_cookie
-    - kselftest-vsyscall-mode-native/bpf_test_socket_cookie
     url: https://bugs.linaro.org/show_bug.cgi?id=3976
     active: true
     intermittent: true

--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -1057,13 +1057,21 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=4036
     active: true
     intermittent: false
-  - environments: *environments_i386
+  - test_names:
+    - kselftest/bpf_test_netcnt
     notes: >
        kselftest: i386: bpf: test_netcnt : libbpf: failed to create map
        (name: 'percpu_netcnt'): Invalid argument
-    projects: *projects_all
-    test_names:
-    - kselftest/bpf_test_netcnt
     url: https://bugs.linaro.org/show_bug.cgi?id=4245
     active: true
     intermittent: false
+    matrix_apply:
+    - environments: *environments_i386
+      projects: *projects_all
+    - environments: *environments_all
+      projects:
+      - lkft/linux-stable-rc-4.19-oe
+      - lkft/linux-stable-rc-4.14-oe
+      - lkft/linux-stable-rc-4.9-oe
+      - lkft/linux-stable-rc-4.4-oe
+      - lkft/linaro-hikey-stable-rc-4.4-oe

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -572,3 +572,17 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=4255
     active: true
     intermittent: true
+  - environments:
+    - hi6220-hikey
+    - juno-r2
+    - qemu_x86_64
+    - qemu_i386
+    - x86
+    notes: >
+      LTP: cpuhotplug05: TBROK: Field 3 is '(hikey)', '0.00' expected
+    projects: *projects_all
+    test_names:
+    - ltp-cpuhotplug-tests/cpuhotplug05
+    url: https://bugs.linaro.org/show_bug.cgi?id=4264
+    active: true
+    intermittent: true

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -552,7 +552,7 @@ projects:
     test_name: ltp-mm-tests/vma05
     url: https://bugs.linaro.org/show_bug.cgi?id=4256
     active: true
-    intermittent: true
+    intermittent: false
   - environments: *environments_64bit
     notes: >
       LTP: mm: overcommit_memory.c:237: BROK: Unexpected error: CommitLimit < Committed_AS
@@ -560,7 +560,7 @@ projects:
     test_name: ltp-mm-tests/overcommit_memory02
     url: https://bugs.linaro.org/show_bug.cgi?id=4257
     active: true
-    intermittent: true
+    intermittent: false
   - environments: *environments_all
     notes: >
       LTP: mm: mem.c:782: BROK: mount /dev/cgroup: ENOENT
@@ -571,7 +571,7 @@ projects:
     - ltp-mm-tests/ksm03_1
     url: https://bugs.linaro.org/show_bug.cgi?id=4255
     active: true
-    intermittent: true
+    intermittent: false
   - environments:
     - hi6220-hikey
     - juno-r2


### PR DESCRIPTION
…rsions

Kernel selftest bpf test_netcnt failed on i386 for all devices and
failed on all devices for 4.19, 4.14, 4.9 and 4.4 kernel versions.

Adding test case bpf_test_netcnt to known issues list.

Ref:
kselftest: i386: bpf: test_netcnt : libbpf: failed to
create map (name: 'percpu_netcnt'): Invalid argument
url: https://bugs.linaro.org/show_bug.cgi?id=4245

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>