### PR TITLE
known-issues: Adding spectre-meltdown-checker known issues list

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -103,34 +103,6 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=4043
     active: true
     intermittent: false
-  - environments:
-    - hi6220-hikey
-    - x15
-    - qemu_arm
-    - qemu_arm64
-    - qemu_i386
-    - qemu_x86_64
-    notes: >
-      LKFT: LTP: pselect01_64: slept for too long
-    projects: *projects_all
-    test_name: ltp-syscalls-tests/pselect01
-    url: https://bugs.linaro.org/show_bug.cgi?id=3089
-    active: true
-    intermittent: false
-  - environments:
-    - hi6220-hikey
-    - x15
-    - qemu_arm
-    - qemu_arm64
-    - qemu_i386
-    - qemu_x86_64
-    notes: >
-      LKFT: LTP: pselect01_64: slept for too long
-    projects: *projects_all
-    test_name: ltp-syscalls-tests/pselect01_64
-    url: https://bugs.linaro.org/show_bug.cgi?id=3089
-    active: true
-    intermittent: false
   - environments: *environments_arm64_arm32
     notes: >
       mainline kernel tests baselining
@@ -271,15 +243,6 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=3327
     active: true
     intermittent: false
-  - environments: *environments_32bit
-    notes: >
-      Test is inconsistent on x15
-      Intermittent failures on qemu_arm and i386
-    projects: *projects_all
-    test_name: ltp-syscalls-tests/fcntl36
-    url: https://bugs.linaro.org/show_bug.cgi?id=3339
-    active: true
-    intermittent: true
   - environments: *environments_arm32
     notes: >
       LKFT: netns_netlink fails on x15 in mainline and 4.15
@@ -411,20 +374,6 @@ projects:
     projects: *projects_all
     test_name: ltp-syscalls-tests/creat08
     url: https://bugs.linaro.org/show_bug.cgi?id=3940
-    active: true
-    intermittent: false
-  - environments:
-    - i386
-    - qemu_x86_64
-    - qemu_arm64
-    - qemu_arm
-    - qemu_i386
-    notes: >
-      LKFT: next: LTP open11 failed - Got:
-      TEST_ERRNO=EACCES(13): Permission denied instead of errno 0
-    projects: *projects_all
-    test_name: ltp-syscalls-tests/open11
-    url: https://bugs.linaro.org/show_bug.cgi?id=3948
     active: true
     intermittent: false
   - environments: *environments_all

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -1,0 +1,71 @@
+globals:
+  - environments: &environments_arm32
+    - x15
+    - qemu_arm
+  - environments: &environments_i386
+    - i386
+    - qemu_i386
+projects:
+- name: LKFT-spectre-meltdown-checker
+  projects: &projects_all
+    - lkft/linux-next-oe
+    - lkft/linux-mainline-oe
+    - lkft/linux-stable-rc-4.20-oe
+    - lkft/linux-stable-rc-4.19-oe
+    - lkft/linux-stable-rc-4.14-oe
+    - lkft/linux-stable-rc-4.9-oe
+    - lkft/linux-stable-rc-4.4-oe
+    - lkft/linaro-hikey-stable-rc-4.4-oe
+  url: https://qa-reports.linaro.org
+  environments: &environments_all
+  - dragonboard-410c
+  - hi6220-hikey
+  - i386
+  - juno-r2
+  - qemu_x86_64
+  - qemu_i386
+  - qemu_arm
+  - qemu_arm64
+  - x15
+  - x86
+  known_issues:
+  - environments: *environments_i386
+    notes: >
+      CVE-2017-5754: VULN PTI is needed to mitigate the vulnerability
+      CVE-2018-3620: VULN Vulnerable
+    projects: *projects_all
+    test_names:
+    - spectre-meltdown-checker-test/CVE-2017-5754
+    - spectre-meltdown-checker-test/CVE-2018-3620
+    url: null
+    active: true
+    intermittent: false
+  - environments:
+    - x86
+    - i386
+    notes: >
+      CVE-2018-3615: VULN your CPU supports SGX and the microcode is not up
+      to date
+    projects: *projects_all
+    test_names:
+    - spectre-meltdown-checker-test/CVE-2018-3615
+    url: null
+    active: true
+    intermittent: false
+  - environments:
+    - juno-r2
+    - i386
+    - x86
+    - qemu_x86_64
+    - qemu_i386
+    notes: >
+      CVE-2018-3639: VULN Your CPU doesn't support SSBD
+      CVE-2018-3640: VULN an up-to-date CPU microcode is needed to mitigate
+      this vulnerability
+    projects: *projects_all
+    test_names:
+    - spectre-meltdown-checker-test/CVE-2018-3639
+    - spectre-meltdown-checker-test/CVE-2018-3640
+    url: null
+    active: true
+    intermittent: false


### PR DESCRIPTION
The test suite spectre meltdown checker few test cases are getting failed
Here is the list of tests adding to known issues list.
 - CVE-2018-3639
 - CVE-2018-3640
 - CVE-2018-3615
 - CVE-2018-3620
 - CVE-2017-5754

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>