### PR TITLE
kselftest: proc read as intermittent known failure on vsyscall modes

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -158,9 +158,9 @@ projects:
     intermittent: false
   - environments: *environments_all
     notes: >
-      Adding skiplist according to the below ticket mainline kernel tests baselining
+      Slow running test cases timedout on qemu are marked as known issues
     projects: *projects_all
-    url: https://projects.linaro.org/projects/CTT/queues/issue/CTT-585
+    url: https://bugs.linaro.org/show_bug.cgi?id=4306
     active: true
     intermittent: false
     test_names:

--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -618,7 +618,10 @@ projects:
       LKFT: LKFT: mainline: dragon board 410c: proc read failed - ICMPv6: process
       read is using deprecated sysctl
     projects: *projects_all
-    test_name: kselftest/proc_read
+    test_names:
+    - kselftest/proc_read
+    - kselftest-vsyscall-mode-none/proc_read
+    - kselftest-vsyscall-mode-native/proc_read
     url: https://bugs.linaro.org/show_bug.cgi?id=3744
     active: true
     intermittent: true


### PR DESCRIPTION
Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>