### PR TITLE
LTP: Adding dio13 as known issue on qemu_arm

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -689,3 +689,14 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=4303
     active: true
     intermittent: true
+  - environments:
+    - qemu_arm
+    notes: >
+      LTP: dio: dio13 No space left on device
+      This is a limitation of qemu_arm32
+    projects: *projects_all
+    test_names:
+    - ltp-dio-tests/dio13
+    url: https://bugs.linaro.org/show_bug.cgi?id=4304
+    active: true
+    intermittent: false

--- a/test_data/test-issues-2.yaml
+++ b/test_data/test-issues-2.yaml
@@ -52,6 +52,7 @@ projects:
 - name: LKFT
   projects: &projects_all
     - lkft/linux-mainline-oe
+    - lkft/linux-stable-rc-5.0-oe
     - lkft/linux-stable-rc-4.19-oe
     - lkft/linux-stable-rc-4.20-oe
     - lkft/linux-stable-rc-4.14-oe

--- a/test_sync_known_issues.py
+++ b/test_sync_known_issues.py
@@ -126,7 +126,8 @@ def test_matrix_apply_kselftest_bug():
              'qemu_x86_64', 'qemu_arm', 'qemu_i386', 'x15', 'juno-r2'},
         'lkft/linux-mainline-oe': {'qemu_i386', 'x15', 'qemu_arm', 'i386'},
         'lkft/linux-stable-rc-4.19-oe': {'qemu_i386', 'x15', 'qemu_arm', 'i386'},
-        'lkft/linux-stable-rc-4.20-oe': {'qemu_i386', 'x15', 'qemu_arm', 'i386'}
+        'lkft/linux-stable-rc-4.20-oe': {'qemu_i386', 'x15', 'qemu_arm', 'i386'},
+        'lkft/linux-stable-rc-5.0-oe': {'qemu_i386', 'x15', 'qemu_arm', 'i386'}
         }
 
 


### PR DESCRIPTION
LTP: dio: dio13 No space left on device
This is a limitation of qemu_arm32 so marking this as known issue.

ltp-dio-tests/dio13

Ref:
https://bugs.linaro.org/show_bug.cgi?id=4304

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>