### PR TITLE
LTP: Adding known test failure cve-2017-17053 to all qemu's and i386

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -496,7 +496,12 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=4135
     active: true
     intermittent: true
-  - environments: *environments_qemu
+  - environments:
+    - i386
+    - qemu_i386
+    - qemu_x86_64
+    - qemu_arm
+    - qemu_arm64
     notes: >
       LTP CVE cve-2017-17053 fails intermittently.
       Marking this test as known issue for i386 and qemu_i386.


### PR DESCRIPTION
Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>