### PR TITLE
kselftests: Adding test_tcpnotify_user to old kernel branches

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -1219,7 +1219,10 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=4346
     active: true
     intermittent: false
-  - environments: *environments_32bit
+  - test_names:
+    - kselftest/bpf_test_tcpnotify_user
+    - kselftest-vsyscall-mode-none/bpf_test_tcpnotify_user
+    - kselftest-vsyscall-mode-native/bpf_test_tcpnotify_user
     notes: >
       Newly added test case selftests: bpf: test_tcpnotify_user is getting failed on 32bit
       architectures x15 and i386.
@@ -1228,11 +1231,16 @@ projects:
       FAILED: load_bpf_file failed for: test_tcpnotify_kern.o
       PASSED on linux next 20190605 default in tree source.
       close this known issues when we upgrade to 5.2 kselftest version and 5.2 kernel.
-    projects: *projects_all
-    test_names:
-    - kselftest/bpf_test_tcpnotify_user
-    - kselftest-vsyscall-mode-none/bpf_test_tcpnotify_user
-    - kselftest-vsyscall-mode-native/bpf_test_tcpnotify_user
+    matrix_apply:
+    - environments: *environments_32bit
+      projects: *projects_all
+    - environments: *environments_all
+      projects:
+      - lkft/linux-stable-rc-4.19-oe
+      - lkft/linux-stable-rc-4.14-oe
+      - lkft/linux-stable-rc-4.9-oe
+      - lkft/linux-stable-rc-4.4-oe
+      - lkft/linaro-hikey-stable-rc-4.4-oe
     url: https://bugs.linaro.org/show_bug.cgi?id=4317
     active: true
     intermittent: false


### PR DESCRIPTION
Adding test_tcpnotify_user as XFAIL for
all 32bit for all branches
all devices for 4.19, 4.14, 4.9 and 4.4

    - environments: *environments_32bit
      projects: *projects_all
    - environments: *environments_all
      projects:
      - lkft/linux-stable-rc-4.19-oe
      - lkft/linux-stable-rc-4.14-oe
      - lkft/linux-stable-rc-4.9-oe
      - lkft/linux-stable-rc-4.4-oe
      - lkft/linaro-hikey-stable-rc-4.4-oe

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>