### PR TITLE
LTP Adding known issues for juno compat kasan and 64k page size

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -539,7 +539,11 @@ projects:
       LTP: fsetxattr02 and fgetxattr02 failed with error ENXIO
       (No such device or address)
     projects: *projects_all
-    test_name: ltp-syscalls-tests/fgetxattr02
+    test_names:
+    - ltp-syscalls-tests/fgetxattr02
+    - ltp-syscalls-compat-tests/fgetxattr02
+    - ltp-syscalls-64k-page_size-tests/fgetxattr02
+    - ltp-syscalls-kasan-tests/fgetxattr02
     url: https://bugs.linaro.org/show_bug.cgi?id=4011
     active: true
     intermittent: false

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -907,6 +907,7 @@ projects:
     - qemu_arm
     - qemu_arm64
     - qemu_i386
+    - juno-r2
     notes: >
       LTP copy_file_range02 failed on i386, qemu_i386, qemu_x86_64, qemu_arm and x15 device.
       copy_file_range returned wrong value 32
@@ -917,11 +918,10 @@ projects:
       copy_file_range02.c:136: FAIL: copy_file_range returned wrong value: 32
       copy_file_range02.c:136: FAIL: copy_file_range returned wrong value: 16
 
-    projects:
-    - lkft/linux-mainline-oe
-    - lkft/linux-stable-rc-5.5-oe
-    - lkft/linux-stable-rc-5.4-oe
-    test_name: ltp-syscalls-tests/copy_file_range02
+    projects: *projects_all
+    test_names:
+    - ltp-syscalls-tests/copy_file_range02
+    - ltp-syscalls-compat-tests/copy_file_range02
     url: https://bugs.linaro.org/show_bug.cgi?id=5554
     active: true
     intermittent: false

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -140,7 +140,11 @@ projects:
     notes: >
       mainline kernel tests baselining
     projects: *projects_all
-    test_name: ltp-syscalls-tests/quotactl01
+    test_names:
+    - ltp-syscalls-tests/quotactl01
+    - ltp-syscalls-compat-tests/quotactl01
+    - ltp-syscalls-64k-page_size-tests/quotactl01
+    - ltp-syscalls-kasan-tests/quotactl01
     url: https://projects.linaro.org/projects/CTT/queues/issue/CTT-585
     active: true
     intermittent: false


### PR DESCRIPTION
Following known test failures added,
 - fgetxattr02
 - quotactl01
 - copy_file_range02