### PR TITLE
LKFT: Adding rseq_basic_percpu_ops_test as known intermittent failure…

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -963,12 +963,15 @@ projects:
     - kselftest-vsyscall-mode-none/rseq_basic_percpu_ops_test
     - kselftest-vsyscall-mode-native/rseq_basic_percpu_ops_test
     notes: >
-      LKFT: Kselftest: rseq: tests not building for arm64 for mainline but test pass on -next
+      LKFT: Kselftest: rseq: tests getting timeout
+      FAIL 2 selftests rseq basic_percpu_ops_test  TIMEOUT
     url: https://bugs.linaro.org/show_bug.cgi?id=3923
     active: true
-    intermittent: false
+    intermittent: true
     matrix_apply:
     - environments: *environments_arm64
+      projects: *projects_all
+    - environments: *environments_32bit
       projects: *projects_all
     - environments: *environments_all
       projects:

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -87,3 +87,16 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=5611
     active: true
     intermittent: false
+  - environments:
+    - x86
+    notes: >
+      TESTNAME=vmx TIMEOUT=90s ACCEL= ./x86/run x86/vmx.flat -smp 1 -cpu host,+vmx
+      -append \"-exit_monitor_from_l2_test -ept_access* -vmx_smp*
+      -vmx_vmcs_shadow_test -atomic_switch_overflow_msrs_test
+      -vmx_init_signal_test -vmx_apic_passthrough_tpr_threshold_test\"
+      FAIL vmx
+    projects: *projects_all
+    test_name: kvm-unit-tests/vmx
+    url: https://bugs.linaro.org/show_bug.cgi?id=5612
+    active: true
+    intermittent: false

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -74,3 +74,16 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=5610
     active: true
     intermittent: true
+  - environments:
+    - i386
+    notes: >
+      kvm unit test case fails on i386 device
+      PASS on x86_64
+
+      TESTNAME=vmexit_inl_pmtimer TIMEOUT=90s ACCEL= ./x86/run x86/vmexit.flat -smp 1 -append 'inl_from_pmtimer'
+      FAIL vmexit_inl_pmtimer
+    projects: *projects_all
+    test_name: kvm-unit-tests/vmexit_inl_pmtimer
+    url: https://bugs.linaro.org/show_bug.cgi?id=5611
+    active: true
+    intermittent: false

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -63,5 +63,14 @@ projects:
     url: https://bugs.linaro.org/show_bug.cgi?id=5557
     active: true
     intermittent: false
+  - environments: *environments_arm64
+    notes: >
+      micro-bench test fails intermittently on arm64
 
-
+      TESTNAME=micro-bench TIMEOUT=90s ACCEL=kvm ./arm/run arm/micro-bench.flat -smp 2
+      FAIL micro-bench (timeout; duration=90s)
+    projects: *projects_all
+    test_name: kvm-unit-tests/micro-bench
+    url: https://bugs.linaro.org/show_bug.cgi?id=5610
+    active: true
+    intermittent: true


### PR DESCRIPTION
… due to timeout

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>