### PR TITLE
LKFT: Add project name linux-next-master

### DIFF
--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -12,7 +12,7 @@ globals:
 projects:
 - name: LKFT-kvm-unit-tests
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -5,7 +5,7 @@ globals:
 projects:
 - name: LKFT-libhugetlbfs
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -61,7 +61,7 @@ globals:
 projects:
 - name: LKFT-ltp
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe
@@ -843,7 +843,7 @@ projects:
       ref link
       http://lists.linux.it/pipermail/ltp/2019-May/012072.html
     projects:
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.4-oe
     - lkft/linux-stable-rc-5.6-oe
@@ -1042,7 +1042,7 @@ projects:
       LTP syscalls test case mknod07 failed on mainline kernel.
       Test case code to be updated.
     projects:
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     test_name: ltp-syscalls-tests/mknod07
     url: https://bugs.linaro.org/show_bug.cgi?id=5646

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -2,7 +2,7 @@ globals:
 projects:
 - name: LKFT-network-basic-tests
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe

--- a/perf.yaml
+++ b/perf.yaml
@@ -13,7 +13,7 @@ globals:
 projects:
 - name: LKFT-perf
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -8,7 +8,7 @@ globals:
 projects:
 - name: LKFT-spectre-meltdown-checker
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -8,7 +8,7 @@ globals:
 projects:
 - name: LKFT-v4l2-compliance
   projects: &projects_all
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe
@@ -43,7 +43,7 @@ projects:
        check_0(reqbufs.reserved, sizeof(reqbufs.reserved))
        test VIDIOC_REQBUFS/CREATE_BUFS/QUERYBUF: FAIL
     projects:
-    - lkft/linux-next-oe
+    - lkft/linux-next-master
     - lkft/linux-mainline-oe
     - lkft/linux-stable-rc-5.8-oe
     - lkft/linux-stable-rc-5.7-oe


### PR DESCRIPTION
With new changes in gitlab pipeline the project name
for linux next tree and branch name is master.

 - lkft/linux-next-master

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>