### PR TITLE
Cleanup: Remove old stable rc branches 5.8 and 5.9

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -62,8 +62,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y
@@ -292,8 +290,6 @@ projects:
       - lkft/linux-mainline-master
       - lkft/linux-stable-rc-linux-5.11.y
       - lkft/linux-stable-rc-linux-5.10.y
-      - lkft/linux-stable-rc-linux-5.9.y
-      - lkft/linux-stable-rc-linux-5.8.y
       - lkft/linux-stable-rc-linux-5.4.y
   - test_names:
     - kselftest/bpf.test_align
@@ -548,8 +544,6 @@ projects:
     projects:
       - lkft/linux-stable-rc-linux-5.11.y
       - lkft/linux-stable-rc-linux-5.10.y
-      - lkft/linux-stable-rc-linux-5.9.y
-      - lkft/linux-stable-rc-linux-5.8.y
       - lkft/linux-stable-rc-linux-5.4.y
       - lkft/linux-stable-rc-linux-4.19.y
       - lkft/linux-stable-rc-linux-4.14.y
@@ -698,8 +692,6 @@ projects:
       - lkft/linux-stable-rc-linux-4.14.y
       - lkft/linux-stable-rc-linux-4.19.y
       - lkft/linux-stable-rc-linux-5.4.y
-      - lkft/linux-stable-rc-linux-5.8.y
-      - lkft/linux-stable-rc-linux-5.9.y
       - lkft/linux-stable-rc-linux-5.10.y
       - lkft/linux-stable-rc-linux-5.11.y
     - environments: *environments_arm32
@@ -928,8 +920,6 @@ projects:
       projects:
       - lkft/linux-stable-rc-linux-5.11.y
       - lkft/linux-stable-rc-linux-5.10.y
-      - lkft/linux-stable-rc-linux-5.9.y
-      - lkft/linux-stable-rc-linux-5.8.y
       - lkft/linux-stable-rc-linux-5.4.y
       - lkft/linux-stable-rc-linux-4.19.y
       - lkft/linux-stable-rc-linux-4.14.y
@@ -1094,8 +1084,6 @@ projects:
     projects:
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -16,8 +16,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -9,8 +9,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -114,8 +114,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y
@@ -909,8 +907,6 @@ projects:
     - lkft/linux-next-master
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.4.y
-    - lkft/linux-stable-rc-linux-5.8.y
-    - lkft/linux-stable-rc-linux-5.9.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.11.y
     test_names:

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -6,8 +6,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y

--- a/perf.yaml
+++ b/perf.yaml
@@ -17,8 +17,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -12,8 +12,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -12,8 +12,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.11.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.9.y
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
     - lkft/linux-stable-rc-linux-4.14.y
@@ -46,7 +44,6 @@ projects:
     projects:
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-5.8.y
     - lkft/linux-stable-rc-linux-5.4.y
     test_names:
     - v4l2-compliance/VIDIOC_REQBUFS-CREATE_BUFS-QUERYBUF


### PR DESCRIPTION
stable-rc 5.8 and stable-rc 5.9 does not existing any more. So
this patch delete those project entries.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>