### PR TITLE
packetdrill: Adding all tests as known failures

### DIFF
--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -34,18 +34,22 @@ projects:
       packetdrill baseline failures are being added as known failures
     projects: *projects_all
     test_names:
+    - packetdrill/answers:-Operation-not-supported
     - packetdrill/bsd-fast_retransmit-fr-4pkt-sack-bsd.pkt-ipv4
     - packetdrill/bsd-fast_retransmit-fr-4pkt-sack-bsd.pkt-ipv4-mapped-v6
     - packetdrill/bsd-fast_retransmit-fr-4pkt-sack-bsd.pkt-ipv6
+    - packetdrill/fastopen-server-client-ack-dropped-then-recovery-ms-timestamps.pkt-ipv4-mapped-v6
+    - packetdrill/fastopen-server-client-ack-dropped-then-recovery-ms-timestamps.pkt-ipv4
+    - packetdrill/fastopen-server-client-ack-dropped-then-recovery-ms-timestamps.pkt-ipv6
     - packetdrill/linux-fast_retransmit-fr-4pkt-sack-linux.pkt-ipv4
     - packetdrill/linux-fast_retransmit-fr-4pkt-sack-linux.pkt-ipv4-mapped-v6
+    - packetdrill/linux-fast_retransmit-fr-4pkt-sack-linux.pkt-ipv6
     - packetdrill/linux-packetdrill-socket_err.pkt-ipv4
     - packetdrill/linux-packetdrill-socket_err.pkt-ipv4-mapped-v6
     - packetdrill/linux-packetdrill-socket_err.pkt-ipv6
     - packetdrill/linux-packetdrill-socket_wrong_err.pkt-ipv4
     - packetdrill/linux-packetdrill-socket_wrong_err.pkt-ipv4-mapped-v6
     - packetdrill/linux-packetdrill-socket_wrong_err.pkt-ipv6
-    - packetdrill/such-file-or-directory
     - packetdrill/tcp-blocking-blocking-accept.pkt-ipv4
     - packetdrill/tcp-blocking-blocking-accept.pkt-ipv4-mapped-v6
     - packetdrill/tcp-blocking-blocking-accept.pkt-ipv6
@@ -53,41 +57,76 @@ projects:
     - packetdrill/tcp-blocking-blocking-connect.pkt-ipv4-mapped-v6
     - packetdrill/tcp-blocking-blocking-connect.pkt-ipv6
     - packetdrill/tcp-blocking-blocking-read.pkt-ipv4
+    - packetdrill/tcp-blocking-blocking-read.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-blocking-blocking-read.pkt-ipv6
     - packetdrill/tcp-blocking-blocking-write.pkt-ipv4
     - packetdrill/tcp-blocking-blocking-write.pkt-ipv4-mapped-v6
     - packetdrill/tcp-blocking-blocking-write.pkt-ipv6
+    - packetdrill/tcp-close-close-local-close-then-remote-fin.pkt-ipv4
+    - packetdrill/tcp-close-close-local-close-then-remote-fin.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-close-close-local-close-then-remote-fin.pkt-ipv6
+    - packetdrill/tcp-close-close-on-syn-sent.pkt-ipv4
     - packetdrill/tcp-close-close-on-syn-sent.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-close-close-on-syn-sent.pkt-ipv6
+    - packetdrill/tcp-close-close-remote-fin-then-close.pkt-ipv4
     - packetdrill/tcp-close-close-remote-fin-then-close.pkt-ipv4-mapped-v6
     - packetdrill/tcp-close-close-remote-fin-then-close.pkt-ipv6
     - packetdrill/tcp-cwnd_moderation-cwnd-moderation-disorder-no-moderation.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-cwnd_moderation-cwnd-moderation-disorder-no-moderation.pkt-ipv4
     - packetdrill/tcp-cwnd_moderation-cwnd-moderation-disorder-no-moderation.pkt-ipv6
     - packetdrill/tcp-cwnd_moderation-cwnd-moderation-ecn-enter-cwr-no-moderation-700.pkt-ipv4
     - packetdrill/tcp-cwnd_moderation-cwnd-moderation-ecn-enter-cwr-no-moderation-700.pkt-ipv4-mapped-v6
     - packetdrill/tcp-cwnd_moderation-cwnd-moderation-ecn-enter-cwr-no-moderation-700.pkt-ipv6
     - packetdrill/tcp-ecn-ecn-uses-ect0.pkt-ipv4
     - packetdrill/tcp-ecn-ecn-uses-ect0.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-ecn-ecn-uses-ect0.pkt-ipv6
+    - packetdrill/tcp-eor-no-coalesce-large.pkt-ipv4
+    - packetdrill/tcp-eor-no-coalesce-large.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-eor-no-coalesce-large.pkt-ipv6
     - packetdrill/tcp-eor-no-coalesce-retrans.pkt-ipv4
     - packetdrill/tcp-eor-no-coalesce-retrans.pkt-ipv4-mapped-v6
     - packetdrill/tcp-eor-no-coalesce-retrans.pkt-ipv6
+    - packetdrill/tcp-eor-no-coalesce-small.pkt-ipv4
     - packetdrill/tcp-eor-no-coalesce-small.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-eor-no-coalesce-small.pkt-ipv6
+    - packetdrill/tcp-eor-no-coalesce-subsequent.pkt-ipv4
+    - packetdrill/tcp-eor-no-coalesce-subsequent.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-eor-no-coalesce-subsequent.pkt-ipv6
+    - packetdrill/tcp-epoll-epoll_in_edge.pkt-ipv4
+    - packetdrill/tcp-epoll-epoll_in_edge.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-epoll-epoll_in_edge.pkt-ipv6
     - packetdrill/tcp-epoll-epoll_out_edge_default_notsent_lowat.pkt-ipv4
     - packetdrill/tcp-epoll-epoll_out_edge_default_notsent_lowat.pkt-ipv4-mapped-v6
     - packetdrill/tcp-epoll-epoll_out_edge_default_notsent_lowat.pkt-ipv6
+    - packetdrill/tcp-epoll-epoll_out_edge_notsent_lowat.pkt-ipv4
+    - packetdrill/tcp-epoll-epoll_out_edge_notsent_lowat.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-epoll-epoll_out_edge_notsent_lowat.pkt-ipv6
     - packetdrill/tcp-epoll-epoll_out_edge.pkt-ipv4
     - packetdrill/tcp-epoll-epoll_out_edge.pkt-ipv4-mapped-v6
     - packetdrill/tcp-epoll-epoll_out_edge.pkt-ipv6
+    - packetdrill/tcp-gro-gro-mss-option.pkt-ipv4
+    - packetdrill/tcp-gro-gro-mss-option.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-gro-gro-mss-option.pkt-ipv6
+    - packetdrill/tcp-inq-client.pkt-ipv4
     - packetdrill/tcp-inq-client.pkt-ipv4-mapped-v6
     - packetdrill/tcp-inq-client.pkt-ipv6
+    - packetdrill/tcp-inq-server.pkt-ipv4
+    - packetdrill/tcp-inq-server.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-inq-server.pkt-ipv6
     - packetdrill/tcp-ioctl-ioctl-siocinq-fin.pkt-ipv4
     - packetdrill/tcp-ioctl-ioctl-siocinq-fin.pkt-ipv4-mapped-v6
     - packetdrill/tcp-ioctl-ioctl-siocinq-fin.pkt-ipv6
     - packetdrill/tcp-limited_transmit-limited-transmit-no-sack.pkt-ipv4
     - packetdrill/tcp-limited_transmit-limited-transmit-no-sack.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-limited_transmit-limited-transmit-no-sack.pkt-ipv6
     - packetdrill/tcp-limited_transmit-limited-transmit-sack.pkt-ipv4
     - packetdrill/tcp-limited_transmit-limited-transmit-sack.pkt-ipv4-mapped-v6
     - packetdrill/tcp-limited_transmit-limited-transmit-sack.pkt-ipv6
     - packetdrill/tcp-md5-md5-only-on-client-ack.pkt-ipv4
+    - packetdrill/tcp-md5-md5-only-on-client-ack.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-md5-md5-only-on-client-ack.pkt-ipv6
     - packetdrill/tcp-mss-mss-getsockopt-tcp_maxseg-server.pkt-ipv4
+    - packetdrill/tcp-mss-mss-getsockopt-tcp_maxseg-server.pkt-ipv4-mapped-v6
     - packetdrill/tcp-mss-mss-getsockopt-tcp_maxseg-server.pkt-ipv6
     - packetdrill/tcp-mss-mss-setsockopt-tcp_maxseg-client.pkt-ipv4
     - packetdrill/tcp-mss-mss-setsockopt-tcp_maxseg-client.pkt-ipv4-mapped-v6
@@ -97,12 +136,16 @@ projects:
     - packetdrill/tcp-mss-mss-setsockopt-tcp_maxseg-server.pkt-ipv6
     - packetdrill/tcp-mtu_probe-basic-v4.pkt-ipv4
     - packetdrill/tcp-mtu_probe-basic-v4.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-mtu_probe-basic-v6.pkt-ipv6
     - packetdrill/tcp-nagle-https_client.pkt-ipv4
     - packetdrill/tcp-nagle-https_client.pkt-ipv4-mapped-v6
     - packetdrill/tcp-nagle-https_client.pkt-ipv6
     - packetdrill/tcp-nagle-sendmsg_msg_more.pkt-ipv4
     - packetdrill/tcp-nagle-sendmsg_msg_more.pkt-ipv4-mapped-v6
     - packetdrill/tcp-nagle-sendmsg_msg_more.pkt-ipv6
+    - packetdrill/tcp-nagle-sockopt_cork_nodelay.pkt-ipv4
+    - packetdrill/tcp-nagle-sockopt_cork_nodelay.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-nagle-sockopt_cork_nodelay.pkt-ipv6
     - packetdrill/tcp-notsent_lowat-notsent-lowat-default.pkt-ipv4
     - packetdrill/tcp-notsent_lowat-notsent-lowat-default.pkt-ipv4-mapped-v6
     - packetdrill/tcp-notsent_lowat-notsent-lowat-default.pkt-ipv6
@@ -124,7 +167,17 @@ projects:
     - packetdrill/tcp-sack-sack-shift-sacked-7-5-6-8-9-fack.pkt-ipv4
     - packetdrill/tcp-sack-sack-shift-sacked-7-5-6-8-9-fack.pkt-ipv4-mapped-v6
     - packetdrill/tcp-sack-sack-shift-sacked-7-5-6-8-9-fack.pkt-ipv6
+    - packetdrill/tcp-sendfile-sendfile-simple.pkt-ipv4
+    - packetdrill/tcp-sendfile-sendfile-simple.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-sendfile-sendfile-simple.pkt-ipv6
+    - packetdrill/tcp-shutdown-shutdown-rd-close.pkt-ipv4
+    - packetdrill/tcp-shutdown-shutdown-rd-close.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-shutdown-shutdown-rd-close.pkt-ipv6
+    - packetdrill/tcp-shutdown-shutdown-rd-wr-close.pkt-ipv4
+    - packetdrill/tcp-shutdown-shutdown-rdwr-close.pkt-ipv4
     - packetdrill/tcp-shutdown-shutdown-rd-wr-close.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-shutdown-shutdown-rdwr-close.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-shutdown-shutdown-rd-wr-close.pkt-ipv6
     - packetdrill/tcp-shutdown-shutdown-rdwr-close.pkt-ipv6
     - packetdrill/tcp-shutdown-shutdown-rdwr-send-queue-ack-close.pkt-ipv4
     - packetdrill/tcp-shutdown-shutdown-rdwr-send-queue-ack-close.pkt-ipv4-mapped-v6
@@ -132,12 +185,24 @@ projects:
     - packetdrill/tcp-shutdown-shutdown-rdwr-write-queue-close.pkt-ipv4
     - packetdrill/tcp-shutdown-shutdown-rdwr-write-queue-close.pkt-ipv4-mapped-v6
     - packetdrill/tcp-shutdown-shutdown-rdwr-write-queue-close.pkt-ipv6
+    - packetdrill/tcp-shutdown-shutdown-wr-close.pkt-ipv4
+    - packetdrill/tcp-shutdown-shutdown-wr-close.pkt-ipv4-mapped-v6
     - packetdrill/tcp-shutdown-shutdown-wr-close.pkt-ipv6
+    - packetdrill/tcp-splice-tcp_splice_loop_test.pkt-ipv4
+    - packetdrill/tcp-splice-tcp_splice_loop_test.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-splice-tcp_splice_loop_test.pkt-ipv6
     - packetdrill/tcp-syscall_bad_arg-fastopen-invalid-buf-ptr.pkt-ipv4
     - packetdrill/tcp-syscall_bad_arg-fastopen-invalid-buf-ptr.pkt-ipv4-mapped-v6
     - packetdrill/tcp-syscall_bad_arg-fastopen-invalid-buf-ptr.pkt-ipv6
     - packetdrill/tcp-syscall_bad_arg-sendmsg-empty-iov.pkt-ipv4
+    - packetdrill/tcp-syscall_bad_arg-sendmsg-empty-iov.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-syscall_bad_arg-sendmsg-empty-iov.pkt-ipv6
+    - packetdrill/tcp-syscall_bad_arg-syscall-invalid-buf-ptr.pkt-ipv4
     - packetdrill/tcp-syscall_bad_arg-syscall-invalid-buf-ptr.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-syscall_bad_arg-syscall-invalid-buf-ptr.pkt-ipv6
+    - packetdrill/tcp-tcp_info-tcp-info-last_data_recv.pkt-ipv4
+    - packetdrill/tcp-tcp_info-tcp-info-last_data_recv.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-tcp_info-tcp-info-last_data_recv.pkt-ipv6
     - packetdrill/tcp-tcp_info-tcp-info-rwnd-limited.pkt-ipv4
     - packetdrill/tcp-tcp_info-tcp-info-rwnd-limited.pkt-ipv4-mapped-v6
     - packetdrill/tcp-tcp_info-tcp-info-rwnd-limited.pkt-ipv6
@@ -147,25 +212,64 @@ projects:
     - packetdrill/tcp-timestamping-client-only-last-byte.pkt-ipv4
     - packetdrill/tcp-timestamping-client-only-last-byte.pkt-ipv4-mapped-v6
     - packetdrill/tcp-timestamping-client-only-last-byte.pkt-ipv6
+    - packetdrill/tcp-timestamping-partial.pkt-ipv4
+    - packetdrill/tcp-timestamping-partial.pkt-ipv4-mapped-v6
     - packetdrill/tcp-timestamping-partial.pkt-ipv6
+    - packetdrill/tcp-timestamping-server.pkt-ipv4
+    - packetdrill/tcp-timestamping-server.pkt-ipv4-mapped-v6
     - packetdrill/tcp-timestamping-server.pkt-ipv6
+    - packetdrill/tcp-ts_recent-fin_tsval.pkt-ipv4
+    - packetdrill/tcp-ts_recent-fin_tsval.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-ts_recent-fin_tsval.pkt-ipv6
     - packetdrill/tcp-ts_recent-invalid_ack.pkt-ipv4
+    - packetdrill/tcp-ts_recent-invalid_ack.pkt-ipv4-mapped-v6
     - packetdrill/tcp-ts_recent-invalid_ack.pkt-ipv6
     - packetdrill/tcp-ts_recent-reset_tsval.pkt-ipv4
+    - packetdrill/tcp-ts_recent-reset_tsval.pkt-ipv4-mapped-v6
     - packetdrill/tcp-ts_recent-reset_tsval.pkt-ipv6
+    - packetdrill/tcp-user_timeout-user_timeout.pkt-ipv4
+    - packetdrill/tcp-user_timeout-user_timeout.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-user_timeout-user_timeout.pkt-ipv6
     - packetdrill/tcp-user_timeout-user-timeout-probe.pkt-ipv4
     - packetdrill/tcp-user_timeout-user-timeout-probe.pkt-ipv4-mapped-v6
     - packetdrill/tcp-user_timeout-user-timeout-probe.pkt-ipv6
+    - packetdrill/tcp-validate-validate-established-no-flags.pkt-ipv4
+    - packetdrill/tcp-validate-validate-established-no-flags.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-validate-validate-established-no-flags.pkt-ipv6
+    - packetdrill/tcp-zerocopy-basic.pkt-ipv4
+    - packetdrill/tcp-zerocopy-basic.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-zerocopy-basic.pkt-ipv6
+    - packetdrill/tcp-zerocopy-batch.pkt-ipv4
+    - packetdrill/tcp-zerocopy-batch.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-zerocopy-batch.pkt-ipv6
     - packetdrill/tcp-zerocopy-client.pkt-ipv4
+    - packetdrill/tcp-zerocopy-client.pkt-ipv4-mapped-v6
     - packetdrill/tcp-zerocopy-client.pkt-ipv6
+    - packetdrill/tcp-zerocopy-closed.pkt-ipv4
     - packetdrill/tcp-zerocopy-closed.pkt-ipv4-mapped-v6
     - packetdrill/tcp-zerocopy-closed.pkt-ipv6
+    - packetdrill/tcp-zerocopy-epoll_edge.pkt-ipv4
+    - packetdrill/tcp-zerocopy-epoll_edge.pkt-ipv4-mapped-v6
     - packetdrill/tcp-zerocopy-epoll_edge.pkt-ipv6
+    - packetdrill/tcp-zerocopy-epoll_exclusive.pkt-ipv4
+    - packetdrill/tcp-zerocopy-epoll_exclusive.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-zerocopy-epoll_exclusive.pkt-ipv6
+    - packetdrill/tcp-zerocopy-epoll_oneshot.pkt-ipv4
+    - packetdrill/tcp-zerocopy-epoll_oneshot.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-zerocopy-epoll_oneshot.pkt-ipv6
+    - packetdrill/tcp-zerocopy-fastopen-client.pkt-ipv4
+    - packetdrill/tcp-zerocopy-fastopen-client.pkt-ipv4-mapped-v6
     - packetdrill/tcp-zerocopy-fastopen-client.pkt-ipv6
     - packetdrill/tcp-zerocopy-fastopen-server.pkt-ipv4
     - packetdrill/tcp-zerocopy-fastopen-server.pkt-ipv4-mapped-v6
     - packetdrill/tcp-zerocopy-fastopen-server.pkt-ipv6
+    - packetdrill/tcp-zerocopy-maxfrags.pkt-ipv4
+    - packetdrill/tcp-zerocopy-maxfrags.pkt-ipv4-mapped-v6
     - packetdrill/tcp-zerocopy-maxfrags.pkt-ipv6
+    - packetdrill/tcp-zerocopy-small.pkt-ipv4
+    - packetdrill/tcp-zerocopy-small.pkt-ipv4-mapped-v6
+    - packetdrill/tcp-zerocopy-small.pkt-ipv6
+    - packetdrill/vs-actual-2000-bytes
     url: https://bugs.linaro.org/show_bug.cgi?id=5761
     active: true
     intermittent: true


### PR DESCRIPTION
The packetdrill test failures are not stable due to timing errors
timing error: expected inbound packet at 0.201418 sec but happened at 0.205890 sec; tolerance 0.004000 sec

because of above reasons adding all test cases as known failure.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>