### PR TITLE
Adding new qemu environments

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -7,35 +7,95 @@ globals:
     - qemu_arm64
     - nxp-ls2088
     - fx700
+    - qemu-arm64-clang
+    - qemu-arm64-debug
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-kasan
+    - qemu-arm64-mte
   - environments: &environments_arm32
     - x15
     - qemu_arm
+    - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
   - environments: &environments_x86_64
     - x86
     - x86-kasan
     - qemu_x86_64
+    - qemu-x86_64-clang
+    - qemu-x86_64-debug
+    - qemu-x86_64-debug-kmemleak
+    - qemu-x86_64-kasan
+    - qemu-x86_64-kcsan
   - environments: &environments_i386
     - i386
     - qemu_i386
+    - qemu-i386-clang
+    - qemu-i386-debug
+    - qemu-i386-debug-kmemleak
   - environments: &environments_qemu
     - qemu_arm
     - qemu_arm64
     - qemu_i386
+    - qemu-i386-clang
+    - qemu-i386-debug
+    - qemu-i386-debug-kmemleak
     - qemu_x86_64
+    - qemu-x86_64-clang
+    - qemu-x86_64-debug
+    - qemu-x86_64-debug-kmemleak
+    - qemu-x86_64-kasan
+    - qemu-x86_64-kcsan
+    - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
+    - qemu-arm64-clang
+    - qemu-arm64-debug
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-kasan
+    - qemu-arm64-mte
   - environments: &environments_32bit
     - i386
     - qemu_i386
+    - qemu-i386-clang
+    - qemu-i386-debug
+    - qemu-i386-debug-kmemleak
     - qemu_arm
     - x15
+    - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
   - environments: &environments_qemu_arm
     - qemu_arm
     - qemu_arm64
+    - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
+    - qemu-arm64-clang
+    - qemu-arm64-debug
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-kasan
+    - qemu-arm64-mte
   - environments: &environments_intel
     - i386
     - qemu_i386
+    - qemu-i386-clang
+    - qemu-i386-debug
+    - qemu-i386-debug-kmemleak
     - qemu_x86_64
     - x86
     - x86-kasan
+    - qemu-x86_64-clang
+    - qemu-x86_64-debug
+    - qemu-x86_64-debug-kmemleak
+    - qemu-x86_64-kasan
+    - qemu-x86_64-kcsan
   - environments: &environments_arm64_arm32
     - dragonboard-410c
     - hi6220-hikey
@@ -46,6 +106,16 @@ globals:
     - x15
     - nxp-ls2088
     - fx700
+    - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
+    - qemu-arm64-clang
+    - qemu-arm64-debug
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-kasan
+    - qemu-arm64-mte
   - environments: &environments_arm64_arm32_i386
     - dragonboard-410c
     - hi6220-hikey
@@ -56,8 +126,21 @@ globals:
     - x15
     - i386
     - qemu_i386
+    - qemu-i386-clang
+    - qemu-i386-debug
+    - qemu-i386-debug-kmemleak
     - nxp-ls2088
     - fx700
+    - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
+    - qemu-arm64-clang
+    - qemu-arm64-debug
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-kasan
+    - qemu-arm64-mte
 
 projects:
 - name: LKFT
@@ -80,7 +163,13 @@ projects:
   - juno-r2
   - juno-r2-kasan
   - qemu_x86_64
+  - qemu-x86_64-clang
+  - qemu-x86_64-debug
+  - qemu-x86_64-debug-kmemleak
   - qemu_i386
+  - qemu-i386-clang
+  - qemu-i386-debug
+  - qemu-i386-debug-kmemleak
   - qemu_arm
   - qemu_arm64
   - x15
@@ -88,6 +177,16 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - qemu-arm-clang
+  - qemu-arm-debug
+  - qemu-arm-debug-kmemleak
+  - qemu-arm64-clang
+  - qemu-arm64-debug
+  - qemu-arm64-debug-kmemleak
+  - qemu-arm64-gic-version2
+  - qemu-arm64-gic-version3
+  - qemu-arm64-kasan
+  - qemu-arm64-mte
   known_issues:
   - environments: *environments_all
     notes: >

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -16,11 +16,16 @@ globals:
     - qemu-arm64-debug
     - qemu-arm64-armv8-features
     - fx700
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-mte
   - environments: &environments_arm32
     - x15
     - qemu_arm
     - qemu-arm-clang
     - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
   - environments: &environments_x86_64
     - x86
     - x86-kasan
@@ -51,8 +56,13 @@ globals:
     - qemu-x86_64-kcsan
     - qemu-arm64-debug
     - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
     - qemu-i386-debug
     - qemu-x86_64-debug
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-mte
   - environments: &environments_32bit
     - i386
     - qemu_i386
@@ -61,6 +71,7 @@ globals:
     - qemu-arm-clang
     - x15
     - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
     - qemu-i386-debug
     - qemu_arm64-compat
     - qemu_x86_64-compat
@@ -74,7 +85,12 @@ globals:
     - qemu-arm64-clang
     - qemu-arm64-debug
     - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
     - qemu-arm64-armv8-features
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-mte
   - environments: &environments_intel
     - i386
     - qemu_i386
@@ -98,6 +114,8 @@ globals:
     - qemu_arm64
     - qemu_arm
     - qemu-arm-clang
+    - qemu-arm-debug
+    - qemu-arm-debug-kmemleak
     - x15
     - nxp-ls2088
     - nxp-ls2088-kasan
@@ -106,9 +124,12 @@ globals:
     - qemu-arm64-kasan
     - qemu-arm64-clang
     - qemu-arm64-debug
-    - qemu-arm-debug
     - qemu-arm64-armv8-features
     - fx700
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-mte
   - environments: &environments_64bit
     - dragonboard-410c
     - hi6220-hikey
@@ -134,6 +155,10 @@ globals:
     - qemu-x86_64-debug
     - qemu-arm64-armv8-features
     - fx700
+    - qemu-arm64-debug-kmemleak
+    - qemu-arm64-gic-version2
+    - qemu-arm64-gic-version3
+    - qemu-arm64-mte
 
 projects:
 - name: LKFT-ltp
@@ -165,6 +190,7 @@ projects:
   - qemu_arm
   - qemu-arm-clang
   - qemu-arm-debug
+  - qemu-arm-debug-kmemleak
   - qemu_arm64
   - x15
   - x86
@@ -183,6 +209,10 @@ projects:
   - qemu-x86_64-kcsan
   - qemu-x86_64-debug
   - fx700
+  - qemu-arm64-debug-kmemleak
+  - qemu-arm64-gic-version2
+  - qemu-arm64-gic-version3
+  - qemu-arm64-mte
   known_issues:
   - environments:
     - hi6220-hikey


### PR DESCRIPTION
Adding following qemu environments,
    - qemu-i386-clang
    - qemu-i386-debug
    - qemu-i386-debug-kmemleak
    - qemu_x86_64
    - qemu-x86_64-clang
    - qemu-x86_64-debug
    - qemu-x86_64-debug-kmemleak
    - qemu-x86_64-kasan
    - qemu-x86_64-kcsan
    - qemu-arm-clang
    - qemu-arm-debug
    - qemu-arm-debug-kmemleak
    - qemu-arm64-clang
    - qemu-arm64-debug
    - qemu-arm64-debug-kmemleak
    - qemu-arm64-gic-version2
    - qemu-arm64-gic-version3
    - qemu-arm64-kasan
    - qemu-arm64-mte