### PR TITLE
LTP: Adding intermittent failure cve-2019-8912

### DIFF
--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -913,6 +913,10 @@ projects:
     - juno-r2-compat
     - juno-64k_page_size
     - x15
+    - qemu_arm64
+    - qemu-arm64-debug
+    - qemu-arm64-kasan
+    - qemu-arm64-clang
     notes: >
       LTP: getrusage04 failed - stime increased > 6000u
       intermittently failed on x15 and juno-r2


### PR DESCRIPTION
f_alg07.c:110: TFAIL: fchownat() failed to fail, kernel may be vulnerable

HINT: You _MAY_ be missing kernel fixes, see:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ff7b11aa481f
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9060cb719e61

HINT: You _MAY_ be vulnerable to CVE(s), see:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912

ref:
https://bugs.linaro.org/show_bug.cgi?id=5802

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>