### PR TITLE
known issues: Remove obsolete projects

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -148,8 +148,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.14.y
-    - lkft/linux-stable-rc-linux-5.13.y
-    - lkft/linux-stable-rc-linux-5.12.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
@@ -605,8 +603,6 @@ projects:
     projects:
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.14.y
-      - lkft/linux-stable-rc-linux-5.13.y
-      - lkft/linux-stable-rc-linux-5.12.y
       - lkft/linux-stable-rc-linux-5.10.y
       - lkft/linux-stable-rc-linux-5.4.y
       - lkft/linux-stable-rc-linux-4.19.y
@@ -739,8 +735,6 @@ projects:
       projects:
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.14.y
-      - lkft/linux-stable-rc-linux-5.13.y
-      - lkft/linux-stable-rc-linux-5.12.y
       - lkft/linux-stable-rc-linux-5.10.y
       - lkft/linux-stable-rc-linux-5.4.y
       - lkft/linux-stable-rc-linux-4.19.y
@@ -947,8 +941,6 @@ projects:
       projects:
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.14.y
-      - lkft/linux-stable-rc-linux-5.13.y
-      - lkft/linux-stable-rc-linux-5.12.y
       - lkft/linux-stable-rc-linux-5.10.y
       - lkft/linux-stable-rc-linux-5.4.y
       - lkft/linux-stable-rc-linux-4.19.y

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -17,8 +17,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.14.y
-    - lkft/linux-stable-rc-linux-5.13.y
-    - lkft/linux-stable-rc-linux-5.12.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -9,8 +9,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.14.y
-    - lkft/linux-stable-rc-linux-5.13.y
-    - lkft/linux-stable-rc-linux-5.12.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -167,8 +167,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.14.y
-    - lkft/linux-stable-rc-linux-5.13.y
-    - lkft/linux-stable-rc-linux-5.12.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y
@@ -981,8 +979,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-5.10.y
-    - lkft/linux-stable-rc-linux-5.12.y
-    - lkft/linux-stable-rc-linux-5.13.y
     - lkft/linux-stable-rc-linux-5.14.y
     - lkft/linux-stable-rc-linux-5.15.y
     test_names:

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -6,8 +6,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.14.y
-    - lkft/linux-stable-rc-linux-5.13.y
-    - lkft/linux-stable-rc-linux-5.12.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y


### PR DESCRIPTION
Following obsolete projects have been deleted,
   - lkft/linux-stable-rc-linux-5.13.y
   - lkft/linux-stable-rc-linux-5.12.y

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>