### PR TITLE
Known-issues: Adding new device type bcm2711-rpi-4-b

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -7,6 +7,7 @@ globals:
     - qemu_arm64
     - nxp-ls2088
     - fx700
+    - bcm2711-rpi-4-b
     - qemu-arm64-clang
     - qemu-arm64-debug
     - qemu-arm64-debug-kmemleak
@@ -106,6 +107,7 @@ globals:
     - x15
     - nxp-ls2088
     - fx700
+    - bcm2711-rpi-4-b
     - qemu-arm-clang
     - qemu-arm-debug
     - qemu-arm-debug-kmemleak
@@ -131,6 +133,7 @@ globals:
     - qemu-i386-debug-kmemleak
     - nxp-ls2088
     - fx700
+    - bcm2711-rpi-4-b
     - qemu-arm-clang
     - qemu-arm-debug
     - qemu-arm-debug-kmemleak
@@ -179,6 +182,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   - qemu-arm-clang
   - qemu-arm-debug
   - qemu-arm-debug-kmemleak
@@ -333,6 +337,7 @@ projects:
       - qemu_i386
       - nxp-ls2088
       - fx700
+      - bcm2711-rpi-4-b
       projects: *projects_all
     - environments: *environments_all
       projects:
@@ -694,6 +699,7 @@ projects:
     - qemu_x86_64
     - nxp-ls2088
     - fx700
+    - bcm2711-rpi-4-b
     notes: >
       LKFT: LKFT: mainline: dragon board 410c: proc read failed - ICMPv6: process
       read is using deprecated sysctl

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -7,6 +7,7 @@ globals:
     - qemu_arm64
     - nxp-ls2088
     - fx700
+    - bcm2711-rpi-4-b
   - environments: &environments_arm32
     - x15
     - qemu_arm
@@ -40,6 +41,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments: *environments_arm64
     notes: >

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -32,6 +32,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments: *environments_all
     notes: >

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -16,6 +16,7 @@ globals:
     - qemu-arm64-debug
     - qemu-arm64-armv8-features
     - fx700
+    - bcm2711-rpi-4-b
     - qemu-arm64-debug-kmemleak
     - qemu-arm64-gic-version2
     - qemu-arm64-gic-version3
@@ -126,6 +127,7 @@ globals:
     - qemu-arm64-debug
     - qemu-arm64-armv8-features
     - fx700
+    - bcm2711-rpi-4-b
     - qemu-arm64-debug-kmemleak
     - qemu-arm64-gic-version2
     - qemu-arm64-gic-version3
@@ -155,6 +157,7 @@ globals:
     - qemu-x86_64-debug
     - qemu-arm64-armv8-features
     - fx700
+    - bcm2711-rpi-4-b
     - qemu-arm64-debug-kmemleak
     - qemu-arm64-gic-version2
     - qemu-arm64-gic-version3
@@ -211,6 +214,7 @@ projects:
   - qemu-x86_64-debug
   - qemu-x86_64-debug-kmemleak
   - fx700
+  - bcm2711-rpi-4-b
   - qemu-arm64-debug-kmemleak
   - qemu-arm64-gic-version2
   - qemu-arm64-gic-version3
@@ -1094,6 +1098,7 @@ projects:
     - nxp-ls2088
     - nxp-ls2088-64k_page_size
     - fx700
+    - bcm2711-rpi-4-b
     notes: >
       These listed test cases failed on nxp-ls2088
       because tests running on nfs mounted rootfs.
@@ -1493,6 +1498,7 @@ projects:
     - nxp-ls2088-kasan
     - nxp-ls2088-64k_page_size
     - fx700
+    - bcm2711-rpi-4-b
     notes: >
       syscalls/ioctl_loop05.c: skip test on overlay filesystem
 

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -29,6 +29,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments:
     - hi6220-hikey

--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -31,6 +31,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments: *environments_all
     notes: >

--- a/perf.yaml
+++ b/perf.yaml
@@ -42,6 +42,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments:
     - qemu_i386

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -37,6 +37,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments: *environments_i386
     notes: >

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -36,6 +36,7 @@ projects:
   - x86-kasan
   - nxp-ls2088
   - fx700
+  - bcm2711-rpi-4-b
   known_issues:
   - environments: *environments_all
     notes: >


### PR DESCRIPTION
New arm64 device bcm2711-rpi-4-b has been added into LKFT LAVA Lab.
This new device added to known issues device type list.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>