### PR TITLE
Known-issues: Adding new device type dragonboard-845c

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -8,6 +8,7 @@ globals:
     - nxp-ls2088
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
     - qemu-arm64-clang
     - qemu-arm64-debug
     - qemu-arm64-debug-kmemleak
@@ -108,6 +109,7 @@ globals:
     - nxp-ls2088
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
     - qemu-arm-clang
     - qemu-arm-debug
     - qemu-arm-debug-kmemleak
@@ -134,6 +136,7 @@ globals:
     - nxp-ls2088
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
     - qemu-arm-clang
     - qemu-arm-debug
     - qemu-arm-debug-kmemleak
@@ -183,6 +186,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   - qemu-arm-clang
   - qemu-arm-debug
   - qemu-arm-debug-kmemleak
@@ -338,6 +342,7 @@ projects:
       - nxp-ls2088
       - fx700
       - bcm2711-rpi-4-b
+      - dragonboard-845c
       projects: *projects_all
     - environments: *environments_all
       projects:
@@ -700,6 +705,7 @@ projects:
     - nxp-ls2088
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
     notes: >
       LKFT: LKFT: mainline: dragon board 410c: proc read failed - ICMPv6: process
       read is using deprecated sysctl

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -8,6 +8,7 @@ globals:
     - nxp-ls2088
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
   - environments: &environments_arm32
     - x15
     - qemu_arm
@@ -42,6 +43,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments: *environments_arm64
     notes: >

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -33,6 +33,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments: *environments_all
     notes: >

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -128,6 +128,7 @@ globals:
     - qemu-arm64-armv8-features
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
     - qemu-arm64-debug-kmemleak
     - qemu-arm64-gic-version2
     - qemu-arm64-gic-version3
@@ -158,6 +159,7 @@ globals:
     - qemu-arm64-armv8-features
     - fx700
     - bcm2711-rpi-4-b
+    - dragonboard-845c
     - qemu-arm64-debug-kmemleak
     - qemu-arm64-gic-version2
     - qemu-arm64-gic-version3
@@ -215,6 +217,7 @@ projects:
   - qemu-x86_64-debug-kmemleak
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   - qemu-arm64-debug-kmemleak
   - qemu-arm64-gic-version2
   - qemu-arm64-gic-version3

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -30,6 +30,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments:
     - hi6220-hikey

--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -32,6 +32,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments: *environments_all
     notes: >

--- a/perf.yaml
+++ b/perf.yaml
@@ -43,6 +43,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments:
     - qemu_i386

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -38,6 +38,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments: *environments_i386
     notes: >

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -37,6 +37,7 @@ projects:
   - nxp-ls2088
   - fx700
   - bcm2711-rpi-4-b
+  - dragonboard-845c
   known_issues:
   - environments: *environments_all
     notes: >


### PR DESCRIPTION
New arm64 device dragonboard-845c has been added into LKFT LAVA Lab.
This new device added to known issues device type list.