### PR TITLE
5.17.y: Removing stable-rc 5.17.y

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -154,7 +154,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
@@ -615,7 +614,6 @@ projects:
     projects:
       - lkft/linux-stable-rc-linux-5.19.y
       - lkft/linux-stable-rc-linux-5.18.y
-      - lkft/linux-stable-rc-linux-5.17.y
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.10.y
       - lkft/linux-stable-rc-linux-5.4.y
@@ -751,7 +749,6 @@ projects:
       projects:
       - lkft/linux-stable-rc-linux-5.19.y
       - lkft/linux-stable-rc-linux-5.18.y
-      - lkft/linux-stable-rc-linux-5.17.y
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.10.y
       - lkft/linux-stable-rc-linux-5.4.y

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -19,7 +19,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -9,7 +9,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -190,7 +190,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
@@ -1014,7 +1013,6 @@ projects:
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.15.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.18.y
     - lkft/linux-stable-rc-linux-5.19.y
     test_names:

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -6,7 +6,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y

--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -6,7 +6,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y

--- a/perf.yaml
+++ b/perf.yaml
@@ -17,7 +17,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -12,7 +12,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -12,7 +12,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-5.19.y
     - lkft/linux-stable-rc-linux-5.18.y
-    - lkft/linux-stable-rc-linux-5.17.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-4.19.y


### PR DESCRIPTION
Removing obsolete stable-rc 5.17 project.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>