### PR TITLE
 Pin github action ubuntu image to ubuntu-20.04

### DIFF
--- a/.github/workflows/update-known-issues.yml
+++ b/.github/workflows/update-known-issues.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.6] 
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-known-issues.yml
+++ b/.github/workflows/update-known-issues.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   update:
     name: Update Known Issues
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-known-issues.yml
+++ b/.github/workflows/update-known-issues.yml
@@ -6,13 +6,14 @@ jobs:
   update:
     name: Update Known Issues
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
-        with:
-          python-version: '3.6'
 
       - name: Install deps
         run: |


### PR DESCRIPTION
 Pin github action ubuntu image to ubuntu-20.04

ubuntu-20.04 support python 3.6 which is removed from latest image.