### PR TITLE
qa-reports-known-issues: Replace stable-rc-linux-6.0.y with new proje…

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -163,7 +163,7 @@ projects:
 - name: LKFT
   projects: &projects_all
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
@@ -627,7 +627,7 @@ projects:
       (cgroup.helpers.c:97: errno: No such file or directory) Opening
       Cgroup Procs: /mnt/cgroup.procs
     projects:
-      - lkft/linux-stable-rc-linux-6.0.y
+      - lkft/linux-stable-rc-linux-6.2.y
       - lkft/linux-stable-rc-linux-6.1.y
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.10.y
@@ -763,7 +763,7 @@ projects:
     matrix_apply:
     - environments: *environments_all
       projects:
-      - lkft/linux-stable-rc-linux-6.0.y
+      - lkft/linux-stable-rc-linux-6.2.y
       - lkft/linux-stable-rc-linux-6.1.y
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.10.y

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -20,7 +20,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -7,7 +7,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -195,7 +195,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
@@ -1023,7 +1023,7 @@ projects:
     - lkft/linux-stable-rc-linux-5.4.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.15.y
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     test_names:
     - ltp-syscalls/shmctl01

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -4,7 +4,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -4,7 +4,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/perf.yaml
+++ b/perf.yaml
@@ -15,7 +15,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -10,7 +10,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/sync_known_issues.py
+++ b/sync_known_issues.py
@@ -431,7 +431,6 @@ def prune_known_issues(config_data, dry_run=True):
 
 
 def main():
-
     assert not os.path.isfile(
         os.environ.get("HOME") + "/.netrc"
     ), "Error - remove ~/.netrc - see https://github.com/requests/requests/issues/3929"

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -10,7 +10,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
-    - lkft/linux-stable-rc-linux-6.0.y
+    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y


### PR DESCRIPTION
…ct stable-rc-linux-6.2.y

In QA reports known issues removing obsolete project stable-rc-linux-6.0.y and adding new project stable-rc-linux-6.2.y.