### PR TITLE
sync_known_issues.py: fix black warning

### DIFF
--- a/sync_known_issues.py
+++ b/sync_known_issues.py
@@ -431,7 +431,6 @@ def prune_known_issues(config_data, dry_run=True):
 
 
 def main():
-
     assert not os.path.isfile(
         os.environ.get("HOME") + "/.netrc"
     ), "Error - remove ~/.netrc - see https://github.com/requests/requests/issues/3929"


### PR DESCRIPTION
Black release 22.12.0 didn't complain. But now with black release 23.1.0, black enforce empty lines before classes and functions with sticky leading comments.