### PR TITLE
kvm-unit-tests: Drop RPi4 64k-pages

### DIFF
--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -10,7 +10,6 @@ globals:
     - bcm2711-rpi-4-b
     - dragonboard-845c
     - fvp
-    - bcm2711-rpi-4-b-64k_page_size
     - bcm2711-rpi-4-b-clang
   - environments: &environments_arm32
     - x15


### PR DESCRIPTION
We're not testing this combination anymore, which results in an error:
```
Traceback (most recent call last):
  File "/home/ddiaz/devel/qa-reports-known-issues/./sync_known_issues.py", line 481, in <module>
    main()
  File "/home/ddiaz/devel/qa-reports-known-issues/./sync_known_issues.py", line 476, in main
    sync_known_issues(config_data, args.dry_run)
  File "/home/ddiaz/devel/qa-reports-known-issues/./sync_known_issues.py", line 300, in sync_known_issues
    s = SquadProject(project)
  File "/home/ddiaz/devel/qa-reports-known-issues/./sync_known_issues.py", line 220, in __init__
    SquadKnownIssue(
  File "/home/ddiaz/devel/qa-reports-known-issues/./sync_known_issues.py", line 160, in __init__
    self._build_environments_set(config)
  File "/home/ddiaz/devel/qa-reports-known-issues/./sync_known_issues.py", line 171, in _build_environments_set
    raise SquadKnownIssueException(
__main__.SquadKnownIssueException: Incorrect environment for project lkft/linux-next-master: bcm2711-rpi-4-b-64k_page_size
```