### PR TITLE
Clean up: Remove obsolete projects

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -183,8 +183,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
@@ -667,8 +665,6 @@ projects:
     projects:
       - lkft/linux-stable-rc-linux-6.5.y
       - lkft/linux-stable-rc-linux-6.4.y
-      - lkft/linux-stable-rc-linux-6.3.y
-      - lkft/linux-stable-rc-linux-6.2.y
       - lkft/linux-stable-rc-linux-6.1.y
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.10.y
@@ -807,8 +803,6 @@ projects:
       projects:
       - lkft/linux-stable-rc-linux-6.5.y
       - lkft/linux-stable-rc-linux-6.4.y
-      - lkft/linux-stable-rc-linux-6.3.y
-      - lkft/linux-stable-rc-linux-6.2.y
       - lkft/linux-stable-rc-linux-6.1.y
       - lkft/linux-stable-rc-linux-5.15.y
       - lkft/linux-stable-rc-linux-5.10.y

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -23,8 +23,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -10,8 +10,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.4.y
     - lkft/linux-stable-rc-linux-6.5.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -199,8 +199,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y
@@ -1029,8 +1027,6 @@ projects:
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-6.1.y
-    - lkft/linux-stable-rc-linux-6.2.y
-    - lkft/linux-stable-rc-linux-6.3.y
     - lkft/linux-stable-rc-linux-6.4.y
     - lkft/linux-stable-rc-linux-6.5.y
     test_names:

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -6,8 +6,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -6,8 +6,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/perf.yaml
+++ b/perf.yaml
@@ -21,8 +21,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/spectre-meltdown-checker.yaml
+++ b/spectre-meltdown-checker.yaml
@@ -14,8 +14,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.15.y
     - lkft/linux-stable-rc-linux-5.10.y

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -14,8 +14,6 @@ projects:
     - lkft/linux-mainline-master
     - lkft/linux-stable-rc-linux-6.5.y
     - lkft/linux-stable-rc-linux-6.4.y
-    - lkft/linux-stable-rc-linux-6.3.y
-    - lkft/linux-stable-rc-linux-6.2.y
     - lkft/linux-stable-rc-linux-6.1.y
     - lkft/linux-stable-rc-linux-5.10.y
     - lkft/linux-stable-rc-linux-5.4.y


### PR DESCRIPTION
The Linux stable-rc 6.2 and 6.3 branches are obsolete. Cleaning up following projects from known issues list,
    - lkft/linux-stable-rc-linux-6.2.y
    - lkft/linux-stable-rc-linux-6.3.y