### PR TITLE
Adding new stable-rc branch linux-6.8.y

### DIFF
--- a/kselftests-production.yaml
+++ b/kselftests-production.yaml
@@ -187,6 +187,7 @@ projects:
 - name: LKFT
   projects: &projects_all
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y
@@ -674,6 +675,7 @@ projects:
       (cgroup.helpers.c:97: errno: No such file or directory) Opening
       Cgroup Procs: /mnt/cgroup.procs
     projects:
+      - lkft/linux-stable-rc-linux-6.8.y
       - lkft/linux-stable-rc-linux-6.7.y
       - lkft/linux-stable-rc-linux-6.6.y
       - lkft/linux-stable-rc-linux-6.5.y

--- a/kvm-unit-tests.yaml
+++ b/kvm-unit-tests.yaml
@@ -23,6 +23,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y

--- a/libhugetlbfs-production.yaml
+++ b/libhugetlbfs-production.yaml
@@ -8,6 +8,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y

--- a/ltp-production.yaml
+++ b/ltp-production.yaml
@@ -203,6 +203,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y

--- a/network-basic-tests.yaml
+++ b/network-basic-tests.yaml
@@ -4,6 +4,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y

--- a/packetdrill-tests.yaml
+++ b/packetdrill-tests.yaml
@@ -4,6 +4,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y

--- a/v4l2-compliance.yaml
+++ b/v4l2-compliance.yaml
@@ -12,6 +12,7 @@ projects:
   projects: &projects_all
     - lkft/linux-next-master
     - lkft/linux-mainline-master
+    - lkft/linux-stable-rc-linux-6.8.y
     - lkft/linux-stable-rc-linux-6.7.y
     - lkft/linux-stable-rc-linux-6.6.y
     - lkft/linux-stable-rc-linux-6.5.y


### PR DESCRIPTION
The new stable-rc branch linux-6.8.y is announced.

Adding new project name:
  - lkft/linux-stable-rc-linux-6.8.y